### PR TITLE
Add support for Kali Linux and fix broken Amazon Linux support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,20 +14,25 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - name: Store installed Python version
+        run: |
+          echo "::set-env name=PY_VERSION::"\
+          "$(python -c "import platform;print(platform.python_version())")"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: "${{ runner.os }}-pip-test-\
+          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
+            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
-          key: "${{ runner.os }}-pre-commit-\
+          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.mypy_cache
 __pycache__
 .python-version

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,6 +7,6 @@ import_heading_thirdparty=Third-Party Libraries
 import_heading_firstparty=cisagov Libraries
 
 # Should be auto-populated by seed-isort-config hook
-known_third_party=testinfra
+known_third_party=pytest,testinfra
 # These must be manually set to correctly separate them from third party libraries
 known_first_party=

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: Amazon
       versions:
-        - 2018.03
+        - 2
     - name: Debian
       versions:
         - stretch

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        # Kali linux isn't an option here, but it is based on Debian
+        # testing
+        - bullseye
     - name: Fedora
       versions:
         - 29

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,8 @@ platforms:
   #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: kali
+    image: kalilinux/kali-rolling
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,8 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: amazon2018.03
-    image: amazonlinux:2018.03
+  - name: amazonlinux2
+    image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
   - name: debian10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,30 +3,24 @@
 
 # python-dev is usually needed with pip to build the wheels associated
 # with python packages
-- name: Install pip (Debian)
-  package:
-    name:
+- name: Determine Python package names (Debian)
+  set_fact:
+    package_names:
       - python-pip
       - python-dev
       - python3-pip
       - python3-dev
-  when:
-    - ansible_os_family == "Debian"
+  when: ansible_os_family == 'Debian' or ansible_os_family == 'Kali GNU/Linux'
 
-- name: Install pip (AmazonLinux)
-  package:
-    name:
-      - python27-pip
-      - python27-devel
-      - python36-pip
-      - python36-devel
-  when: ansible_os_family == "RedHat" and ansible_distribution == "Amazon"
-
-- name: Install pip (Fedora)
-  package:
-    name:
+- name: Determine Python package names (RedHat)
+  set_fact:
+    package_names:
       - python2-pip
       - python2-devel
       - python3-pip
       - python3-devel
-  when: ansible_os_family == "RedHat" and ansible_distribution == "Fedora"
+  when: ansible_os_family == 'RedHat'
+
+- name: Install python
+  package:
+    name: '{{ package_names }}'


### PR DESCRIPTION
## 🗣 Description

This pull request adds support for Kali Linux and fixes broken Amazon Linux support.

## 💭 Motivation and Context

Kali Linux support is required for the Kali Linux AMI we are building for the COOL.  The upstream skeleton switched to Amazon Linux 2, which broke the Amazon Linux support.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
