### PR TITLE
Use OS-specific vars files instead of set_fact

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,25 +1,20 @@
 ---
 # tasks file for pip
 
-# python-dev is usually needed with pip to build the wheels associated
-# with python packages
-- name: Determine Python package names (Debian)
-  set_fact:
-    package_names:
-      - python-pip
-      - python-dev
-      - python3-pip
-      - python3-dev
-  when: ansible_os_family == 'Debian' or ansible_os_family == 'Kali GNU/Linux'
-
-- name: Determine Python package names (RedHat)
-  set_fact:
-    package_names:
-      - python2-pip
-      - python2-devel
-      - python3-pip
-      - python3-devel
-  when: ansible_os_family == 'RedHat'
+- name: Load var file with package names based on the OS type
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        # The OS family and distribution for Kali is "Kali GNU/Linux",
+        # which is not an allowable file name in Linux due to the
+        # slash.  We will allow Kali to fall through and use the
+        # Debian vars file.
+        - Debian.yml
+      paths:
+        - "vars"
 
 - name: Install python
   package:

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,9 @@
+---
+# vars file for Amazon Linux
+
+# The pip package names
+package_names:
+  - python2-pip
+  - python2-devel
+  - python3-pip
+  - python3-devel

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,9 @@
+---
+# vars file for Debian
+
+# The pip package names
+package_names:
+  - python-pip
+  - python-dev
+  - python3-pip
+  - python3-dev

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,9 @@
+---
+# vars file for RedHat
+
+# The pip package names
+package_names:
+  - python2-pip
+  - python2-devel
+  - python3-pip
+  - python3-devel


### PR DESCRIPTION
## 🗣 Description

Load OS-specific vars files instead of using `set_fact`.  `set_fact` can pollute other Ansible roles that run after this one.

## 💭 Motivation and Context

I ran into a case where the `package_names` fact leftover from one role was overriding the `package_names` variable in another role and causing incorrect packages to be installed.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
