### PR TITLE
Fix role so that it correctly handles Debian 11 (Bullseye)

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -33,7 +33,22 @@ def test_python_debian(host, pkg):
     """Test that the appropriate packages were installed."""
     if (
         host.system_info.distribution == "debian"
-        or host.system_info.distribution == "kali"
+        and (
+            host.system_info.release is not None and int(host.system_info.release) < 11
+        )
+    ) or host.system_info.distribution == "kali":
+        assert host.package(pkg).is_installed
+
+
+@pytest.mark.parametrize("pkg", ["python3-pip", "python3-dev"])
+def test_python_debian_bullseye_and_later(host, pkg):
+    """Test that the appropriate packages were installed.
+
+    The packages python-pip and python-dev no longer exist in Bullseye
+    or later.
+    """
+    if host.system_info.distribution == "debian" and (
+        host.system_info.release is None or int(host.system_info.release) >= 11
     ):
         assert host.package(pkg).is_installed
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -31,6 +31,9 @@ def test_python_amazon(host, pkg):
 )
 def test_python_debian(host, pkg):
     """Test that the appropriate packages were installed."""
+    # host.system_info.release can be None if the release is still a
+    # testing release that has not been officially released yet.  This
+    # is currently (2020/03/27) the case for Debian 11 (Bullseye).
     if (
         host.system_info.distribution == "debian"
         and (
@@ -47,6 +50,9 @@ def test_python_debian_bullseye_and_later(host, pkg):
     The packages python-pip and python-dev no longer exist in Bullseye
     or later.
     """
+    # host.system_info.release can be None if the release is still a
+    # testing release that has not been officially released yet.  This
+    # is currently (2020/03/27) the case for Debian 11 (Bullseye).
     if host.system_info.distribution == "debian" and (
         host.system_info.release is None or int(host.system_info.release) >= 11
     ):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
   vars:
     params:
       files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml"
         - "{{ ansible_distribution }}.yml"
         - "{{ ansible_os_family }}.yml"
         # The OS family and distribution for Kali is "Kali GNU/Linux",

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
         # Debian vars file.
         - Debian.yml
       paths:
-        - "vars"
+        - "{{ role_path }}/vars"
 
 - name: Install pip
   package:

--- a/vars/Debian_NA.yml
+++ b/vars/Debian_NA.yml
@@ -1,0 +1,8 @@
+---
+# vars file for Debian 11
+
+# The pip package names.  python-pip and python-dev were removed in
+# Debian 11.
+package_names:
+  - python3-pip
+  - python3-dev


### PR DESCRIPTION
## 🗣 Description

This pull request modifies the role to correctly handle Debian 11 (Bullseye).  The `python-*` packages were recently removed from Debian 11 in favor of the more specific `python3-*`, and this broke the existing code.

## 💭 Motivation and Context

The Ansible role [cisagov/ansible-role-openvpn](https://github.com/cisagov/ansible-role-openvpn) has this role as a dependency.  When making modifications to that role I realized that it was failing because this role was failing due to the Debian 11 changes described in the previous section.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
