### PR TITLE
Install `pip` on Debian Buster

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,29 +12,29 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["python3-pip", "python3-dev"])
+@pytest.mark.parametrize("pkg", ["python-pip", "python-dev"])
 def test_python_debian(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "debian" and host.system_info.release != "9.12":
+    """Test that the appropriate packages were installed.
+
+    We treat Debian 9 and 10 as special cases because the CyHy AMIs (and
+    only the CyHy AMIs) are built on them.  Therefore they require
+    python2.
+    """
+    if host.system_info.distribution == "debian" and (
+        host.system_info.codename == "stretch" or host.system_info.codename == "buster"
+    ):
         assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize(
-    "pkg", ["python-pip", "python-dev", "python3-pip", "python3-dev"]
-)
-def test_python_debian_9(host, pkg):
-    """Test that the appropriate packages were installed.
-
-    We treat Debian 9 as a special case because the CyHy AMIs (and
-    only the CyHy AMIs) are built on it.  Therefore it requires
-    python2.
-    """
-    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
+@pytest.mark.parametrize("pkg", ["python3-pip", "python3-dev"])
+def test_python3_debian(host, pkg):
+    """Test that the appropriate packages were installed."""
+    if host.system_info.distribution == "debian":
         assert host.package(pkg).is_installed
 
 
 @pytest.mark.parametrize("pkg", ["python3-pip", "python3-devel"])
-def test_python_redhat(host, pkg):
+def test_python3_redhat(host, pkg):
     """Test that the appropriate packages were installed."""
     if (
         host.system_info.distribution == "fedora"

--- a/vars/Debian_buster.yml
+++ b/vars/Debian_buster.yml
@@ -1,0 +1,1 @@
+Debian_stretch.yml

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -1,9 +1,9 @@
 ---
-# vars file for Debian 9
+# vars file for Debian 9 and Debian 10
 
-# The pip package names.  We treat Debian 9 as a special case because
-# the CyHy AMIs (and only the CyHy AMIs) are built on it.  Therefore
-# Debian 9 requires python2 support.
+# The pip package names.  We treat Debian 9 and 10 as special cases because
+# the CyHy AMIs (and only the CyHy AMIs) are built on them.  Therefore
+# Debian 9 and 10 require python2 support.
 package_names:
   - python-pip
   - python-dev


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates this Ansible role to install `pip` (in addition to `pip3`) on Debian Buster systems.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is in support of https://github.com/cisagov/ansible-role-python/pull/45 to allow Python 2 to be installed on Debian Buster systems (in addition to Debian Stretch).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This role is used in my testing branch of [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis) alongside the `cisagov/ansible-role-python` changes mentioned above. I saw no issues and packages could be successfully installed with `pip`.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
