### PR TITLE
Ensure Python 2 packages are installed on Amazon Linux 2

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,6 @@
 import os
 
 # Third-Party Libraries
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -12,32 +11,24 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["python3-pip", "python3-dev"])
-def test_python_debian(host, pkg):
+def test_pip(host):
     """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "debian" and host.system_info.release != "9.12":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize(
-    "pkg", ["python-pip", "python-dev", "python3-pip", "python3-dev"]
-)
-def test_python_debian_9(host, pkg):
-    """Test that the appropriate packages were installed.
-
-    We treat Debian 9 as a special case because the CyHy AMIs (and
-    only the CyHy AMIs) are built on it.  Therefore it requires
-    python2.
-    """
-    if host.system_info.distribution == "debian" and host.system_info.release == "9.12":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["python3-pip", "python3-devel"])
-def test_python_redhat(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if (
-        host.system_info.distribution == "fedora"
-        or host.system_info.distribution == "amzn"
-    ):
-        assert host.package(pkg).is_installed
+    amazon_extra_pkgs = ["python2-pip", "python-devel"]
+    debian_pkgs = ["python3-pip", "python3-dev"]
+    debian_stretch_extra_pkgs = ["python-pip", "python-dev"]
+    redhat_pkgs = ["python3-pip", "python3-devel"]
+    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
+        assert all([host.package(pkg).is_installed for pkg in debian_pkgs])
+        if (
+            host.system_info.distribution == "debian"
+            and host.system_info.codename == "9.12"
+        ):
+            assert all(
+                [host.package(pkg).is_installed for pkg in debian_stretch_extra_pkgs]
+            )
+    elif host.system_info.distribution in ["amzn", "fedora"]:
+        assert all([host.package(pkg).is_installed for pkg in redhat_pkgs])
+        if host.system_info.distribution == "amzn":
+            assert all([host.package(pkg).is_installed for pkg in amazon_extra_pkgs])
+    else:
+        assert False, f"Unknown distribution {host.system_info.distribution}"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -11,14 +11,11 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-def test_pip(host):
-    """Test that the appropriate packages were installed."""
-    amazon_extra_pkgs = ["python2-pip", "python-devel"]
-    debian_pkgs = ["python3-pip", "python3-dev"]
-    debian_stretch_extra_pkgs = ["python-pip", "python-dev"]
-    redhat_pkgs = ["python3-pip", "python3-devel"]
+def test_pip2(host):
+    """Test that the appropriate pip2 packages were installed."""
+    amazon_pkgs = ["python2-pip", "python-devel"]
+    debian_stretch_pkgs = ["python-pip", "python-dev"]
     if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
-        assert all([host.package(pkg).is_installed for pkg in debian_pkgs])
         # We treat Debian 9 as a special case because the CyHy AMIs
         # (and only the CyHy AMIs) are built on it.  Therefore it
         # requires python2.
@@ -26,15 +23,24 @@ def test_pip(host):
             host.system_info.distribution == "debian"
             and host.system_info.codename == "stretch"
         ):
-            assert all(
-                [host.package(pkg).is_installed for pkg in debian_stretch_extra_pkgs]
-            )
+            assert all([host.package(pkg).is_installed for pkg in debian_stretch_pkgs])
     elif host.system_info.distribution in ["amzn", "fedora"]:
-        assert all([host.package(pkg).is_installed for pkg in redhat_pkgs])
         # Amazon Linux 2 is woefully behind the times and requires
         # Python 2 to support its antiquated version of the yum
         # package manager.
         if host.system_info.distribution == "amzn":
-            assert all([host.package(pkg).is_installed for pkg in amazon_extra_pkgs])
+            assert all([host.package(pkg).is_installed for pkg in amazon_pkgs])
+    else:
+        assert False, f"Unknown distribution {host.system_info.distribution}"
+
+
+def test_pip3(host):
+    """Test that the appropriate pip3 packages were installed."""
+    debian_pkgs = ["python3-pip", "python3-dev"]
+    redhat_pkgs = ["python3-pip", "python3-devel"]
+    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
+        assert all([host.package(pkg).is_installed for pkg in debian_pkgs])
+    elif host.system_info.distribution in ["amzn", "fedora"]:
+        assert all([host.package(pkg).is_installed for pkg in redhat_pkgs])
     else:
         assert False, f"Unknown distribution {host.system_info.distribution}"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,6 +19,9 @@ def test_pip(host):
     redhat_pkgs = ["python3-pip", "python3-devel"]
     if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
         assert all([host.package(pkg).is_installed for pkg in debian_pkgs])
+        # We treat Debian 9 as a special case because the CyHy AMIs
+        # (and only the CyHy AMIs) are built on it.  Therefore it
+        # requires python2.
         if (
             host.system_info.distribution == "debian"
             and host.system_info.codename == "9.12"
@@ -28,6 +31,9 @@ def test_pip(host):
             )
     elif host.system_info.distribution in ["amzn", "fedora"]:
         assert all([host.package(pkg).is_installed for pkg in redhat_pkgs])
+        # Amazon Linux 2 is woefully behind the times and requires
+        # Python 2 to support its antiquated version of the yum
+        # package manager.
         if host.system_info.distribution == "amzn":
             assert all([host.package(pkg).is_installed for pkg in amazon_extra_pkgs])
     else:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -24,7 +24,7 @@ def test_pip(host):
         # requires python2.
         if (
             host.system_info.distribution == "debian"
-            and host.system_info.codename == "9.12"
+            and host.system_info.codename == "stretch"
         ):
             assert all(
                 [host.package(pkg).is_installed for pkg in debian_stretch_extra_pkgs]

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -6,7 +6,7 @@
 # Amazon Linux 2 is woefully behind the times and requires Python 2 to
 # support its antiquated version of the yum package manager.
 package_names:
-  - python2-pip
   - python-devel
+  - python2-pip
   - python3-pip
   - python3-devel

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -2,6 +2,9 @@
 # vars file for Amazon Linux
 
 # The pip package names
+#
+# Amazon Linux 2 is woefully behind the times and requires Python 2 to
+# support its antiquated version of the yum package manager.
 package_names:
   - python2-pip
   - python-devel

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,9 @@
+---
+# vars file for Amazon Linux
+
+# The pip package names
+package_names:
+  - python2-pip
+  - python-devel
+  - python3-pip
+  - python3-devel


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Ensures that the necessary Python 2 packages are installed on Amazon Linux 2.
- Adapts the `molecule` test code to the changes from the previous bullet, and also refactors it.

## 💭 Motivation and context ##

- Amazon Linux 2 requires Python 2, so it should be treated just like
Debian Stretch is currently.
- The previous code would pass if the distro wasn't one that was covered by the tests, while this refactored code will fail in such a case.
- I need these changes in order to get the GH Actions checks for cisagov/ansible-role-nessus#17 to pass.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.