### PR TITLE
Control installation of pip2 via a role variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
       matrix:
         scenario:
           - default
+          - python2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/default/tests
+        exclude: molecule/(default|python2)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ apply.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| install_python2 | A boolean indicating whether or not to install pip2 alongside pip3.  Note that this is only possible for Amazon Linux 2, Debian Stretch, Debian Buster, and Ubuntu Bionic; therefore, this role variable is ignored for any other distribution. | `false` | No |
+| install_pip2 | A boolean indicating whether or not to install pip2 alongside pip3.  Note that this is only possible for Amazon Linux 2, Debian Stretch, Debian Buster, and Ubuntu Bionic; therefore, this role variable is ignored for any other distribution. | `false` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,9 @@ apply.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| install_python2 | A boolean indicating whether or not to install pip2 alongside pip3. | `false` | No |
 
 ## Dependencies ##
 
@@ -59,4 +54,4 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-Jeremy Frasier - <jeremy.frasier@trio.dhs.gov>
+Shane Frasier - <jeremy.frasier@trio.dhs.gov>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ apply.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| install_python2 | A boolean indicating whether or not to install pip2 alongside pip3. | `false` | No |
+| install_python2 | A boolean indicating whether or not to install pip2 alongside pip3.  Note that this is only possible for Amazon Linux 2, Debian Stretch, Debian Buster, and Ubuntu Bionic; therefore, this role variable is ignored for any other distribution. | `false` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # Whether or not to install pip2 alongside pip3
-install_pip2: no
+install_pip2: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Whether or not to install pip2 alongside pip3
+install_pip2: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Jeremy Frasier
+  author: Shane Frasier
   description: Ansible role for installing pip
   company: CISA Cyber Assessments
   galaxy_tags:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -11,29 +11,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-def test_pip2(host):
-    """Test that the appropriate pip2 packages were installed."""
-    amazon_pkgs = ["python2-pip", "python-devel"]
-    debian_stretch_pkgs = ["python-pip", "python-dev"]
-    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
-        # We treat Debian 9 as a special case because the CyHy AMIs
-        # (and only the CyHy AMIs) are built on it.  Therefore it
-        # requires python2.
-        if (
-            host.system_info.distribution == "debian"
-            and host.system_info.codename == "stretch"
-        ):
-            assert all([host.package(pkg).is_installed for pkg in debian_stretch_pkgs])
-    elif host.system_info.distribution in ["amzn", "fedora"]:
-        # Amazon Linux 2 is woefully behind the times and requires
-        # Python 2 to support its antiquated version of the yum
-        # package manager.
-        if host.system_info.distribution == "amzn":
-            assert all([host.package(pkg).is_installed for pkg in amazon_pkgs])
-    else:
-        assert False, f"Unknown distribution {host.system_info.distribution}"
-
-
 def test_pip3(host):
     """Test that the appropriate pip3 packages were installed."""
     debian_pkgs = ["python3-pip", "python3-dev"]

--- a/molecule/python2/Dockerfile_debian_9.j2
+++ b/molecule/python2/Dockerfile_debian_9.j2
@@ -1,0 +1,1 @@
+../default/Dockerfile_debian_9.j2

--- a/molecule/python2/INSTALL.rst
+++ b/molecule/python2/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/python2/converge.yml
+++ b/molecule/python2/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-pip
+      ansible.builtin.include_role:
+        name: ansible-role-pip
+      vars:
+        install_pip2: yes

--- a/molecule/python2/molecule-no-systemd.yml
+++ b/molecule/python2/molecule-no-systemd.yml
@@ -1,0 +1,74 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do not_ require SystemD.  If your Ansible role _does_
+# require SystemD then you should use molecule-with-systemd.yml
+# instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: amazonlinux2
+    image: amazonlinux:2
+  - name: debian9
+    image: debian:stretch-slim
+    dockerfile: Dockerfile_debian_9.j2
+  - name: debian10
+    image: debian:buster-slim
+  - name: debian11
+    image: debian:bullseye-slim
+  - name: debian12
+    image: debian:bookworm-slim
+  - name: kali
+    image: kalilinux/kali-rolling
+  - name: fedora34
+    image: fedora:34
+  - name: fedora35
+    image: fedora:35
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      debian9:
+        # auto_legacy is still the default behavior until Ansible 2.12
+        # is released, but Molecule overrides this and forces the use
+        # of auto.
+        #
+        # In auto_legacy mode Ansible will prefer the /usr/bin/python
+        # interpreter if it exists, while in auto mode it will prefer
+        # the Python interpreter specified in an internal map.  In
+        # most cases we only have Python3 installed, and the internal
+        # map specifies /usr/bin/python3, so it is immaterial whether
+        # we use auto_legacy or auto.
+        #
+        # The one place where it _does_ matter is our Debian9 AKA CyHy
+        # instances.  Here the /usr/bin/python _and_ /usr/bin/python3
+        # interpreters are both installed.  In Ansible 2.10 a Debian
+        # entry was added to the internal map, so now auto_legacy
+        # selects the /usr/bin/python interpreter while auto selects
+        # the /usr/bin/python3 interpreter.  We want to maintain the
+        # auto_legacy behavior in this case since CyHy is still
+        # Python2.
+        #
+        # See:
+        # * https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389
+        # * https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py
+        ansible_python_interpreter: auto_legacy
+scenario:
+  name: python2
+verifier:
+  name: testinfra

--- a/molecule/python2/molecule-with-systemd.yml
+++ b/molecule/python2/molecule-with-systemd.yml
@@ -1,0 +1,122 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do_ require SystemD.  If your Ansible role _does not_
+# require SystemD then you should use molecule-no-systemd.yml instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: amazonlinux2-systemd
+    image: geerlingguy/docker-amazonlinux2-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian9-systemd
+    image: geerlingguy/docker-debian9-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian10-systemd
+    image: geerlingguy/docker-debian10-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian11-systemd
+    image: geerlingguy/docker-debian11-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian12-systemd
+    image: cisagov/docker-debian12-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: kali-systemd
+    image: cisagov/docker-kali-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora34-systemd
+    image: geerlingguy/docker-fedora34-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora35-systemd
+    image: geerlingguy/docker-fedora35-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: ubuntu-18-systemd
+    image: geerlingguy/docker-ubuntu1804-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: ubuntu-20-systemd
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      debian9-systemd:
+        # auto_legacy is still the default behavior until Ansible 2.12
+        # is released, but Molecule overrides this and forces the use
+        # of auto.
+        #
+        # In auto_legacy mode Ansible will prefer the /usr/bin/python
+        # interpreter if it exists, while in auto mode it will prefer
+        # the Python interpreter specified in an internal map.  In
+        # most cases we only have Python3 installed, and the internal
+        # map specifies /usr/bin/python3, so it is immaterial whether
+        # we use auto_legacy or auto.
+        #
+        # The one place where it _does_ matter is our Debian9 AKA CyHy
+        # instances.  Here the /usr/bin/python _and_ /usr/bin/python3
+        # interpreters are both installed.  In Ansible 2.10 a Debian
+        # entry was added to the internal map, so now auto_legacy
+        # selects the /usr/bin/python interpreter while auto selects
+        # the /usr/bin/python3 interpreter.  We want to maintain the
+        # auto_legacy behavior in this case since CyHy is still
+        # Python2.
+        #
+        # See:
+        # * https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389
+        # * https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py
+        ansible_python_interpreter: auto_legacy
+scenario:
+  name: python2
+verifier:
+  name: testinfra

--- a/molecule/python2/molecule.yml
+++ b/molecule/python2/molecule.yml
@@ -1,0 +1,1 @@
+molecule-no-systemd.yml

--- a/molecule/python2/prepare.yml
+++ b/molecule/python2/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/python2/requirements.yml
+++ b/molecule/python2/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/python2/tests/test_default.py
+++ b/molecule/python2/tests/test_default.py
@@ -1,0 +1,1 @@
+../../default/tests/test_default.py

--- a/molecule/python2/tests/test_python2.py
+++ b/molecule/python2/tests/test_python2.py
@@ -1,0 +1,33 @@
+"""Module containing the tests for the default scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+def test_pip2(host):
+    """Test that the appropriate pip2 packages were installed."""
+    debian_stretch_pkgs = ["python-dev", "python-pip"]
+    debian_buster_pkgs = ["python-pip", "python2-dev"]
+    debian_pkgs = []
+    amazon_pkgs = ["python-devel", "python2-pip"]
+    redhat_pkgs = []
+    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
+        if host.system_info.codename in ["stretch", "bionic"]:
+            assert all([host.package(pkg).is_installed for pkg in debian_stretch_pkgs])
+        elif host.system_info.codename in ["buster"]:
+            assert all([host.package(pkg).is_installed for pkg in debian_buster_pkgs])
+        else:
+            assert all([host.package(pkg).is_installed for pkg in debian_pkgs])
+    elif host.system_info.distribution in ["amzn"]:
+        assert all([host.package(pkg).is_installed for pkg in amazon_pkgs])
+    elif host.system_info.distribution in ["fedora"]:
+        assert all([host.package(pkg).is_installed for pkg in redhat_pkgs])
+    else:
+        assert False, f"Unknown distribution {host.system_info.distribution}"

--- a/molecule/python2/upgrade.yml
+++ b/molecule/python2/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for pip
-
 - name: Load var file with package names based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
@@ -12,6 +10,11 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Install pip
+- name: Install pip3
   ansible.builtin.package:
-    name: '{{ package_names }}'
+    name: "{{ python3_package_names }}"
+
+- name: Install pip2
+  ansible.builtin.package:
+    name: "{{ python2_package_names }}"
+  when: install_pip2

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,12 +1,10 @@
 ---
-# vars file for Amazon Linux
-
-# The pip package names
-#
-# Amazon Linux 2 is woefully behind the times and requires Python 2 to
-# support its antiquated version of the yum package manager.
-package_names:
+# The Python 2 package names
+python2_package_names:
   - python-devel
   - python2-pip
-  - python3-pip
+
+# The Python 3 package names
+python3_package_names:
   - python3-devel
+  - python3-pip

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,14 @@
 ---
-# vars file for Debian
+# The Python 2 package names
+#
+# No Python 2 pip package is available for Debian Bullseye.  There is
+# one available for Bookworm, but when installed it forces the
+# uninstall of python3-pip.  That isn't the behavior we desire, so we
+# simply don't support Python 2 for package installation via pip after
+# Debian Buster.
+python2_package_names: []
 
-# The pip package names.
-package_names:
-  - python3-pip
+# The Python 3 package names
+python3_package_names:
   - python3-dev
+  - python3-pip

--- a/vars/Debian_buster.yml
+++ b/vars/Debian_buster.yml
@@ -1,7 +1,7 @@
 ---
 # The Python 2 package names
 python2_package_names:
-  - python-dev
+  - python2-dev
   - python-pip
 
 # The Python 3 package names

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,7 +1,12 @@
 ---
-# vars file for RedHat
+# The Python 2 package names
+#
+# No Python 2 pip package is available for Fedora 34 or 35, or any
+# other modern RedHat distributions.  Therefore, we simply don't
+# support Python 2 for package installation via pip.
+python2_package_names: []
 
-# The pip package names
-package_names:
-  - python3-pip
+# The Python 3 package names
+python3_package_names:
   - python3-devel
+  - python3-pip

--- a/vars/Ubuntu_bionic.yml
+++ b/vars/Ubuntu_bionic.yml
@@ -1,0 +1,1 @@
+Debian_stretch.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies this role to control the installation of `pip2` via a role variable.  Previously `pip2` was installed only on Debian Stretch.

Note that I have added the `blocked` label because this PR should be merged along with:
- cisagov/ansible-role-python#46
- cisagov/cyhy_amis#451

## 💭 Motivation and context ##

This change is part of the work that will allow us to build CyHy AMIs on top of on newer Debian releases.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.